### PR TITLE
Handle Windows path separator when download complete

### DIFF
--- a/main-webext.js
+++ b/main-webext.js
@@ -126,7 +126,12 @@ function dlComplete(download_list)
 {
     download = download_list[0];
 
-    var filepath = download.filename.split('/');
+    var pathSep = '/';    // Linux / (probably) OSX
+    if (download.filename.indexOf('/') == -1)
+    {
+        pathSep = '\\'; // Windoze
+    }
+    var filepath = download.filename.split(pathSep);
     var filename = filepath.pop(filepath.length-1);
 
     var timeMs = (new Date()).getTime() - (new Date(download.startTime)).getTime();
@@ -139,7 +144,7 @@ function dlComplete(download_list)
     {
         summary = 'Download Complete: "' + filename + '"';
         body = 'File: "' + filename + '"\n';
-        body += 'Saved in ' + filepath.join('/');
+        body += 'Saved in ' + filepath.join(pathSep);
     }
     else if (download.error != null && !isAlreadyNotified)
     {


### PR DESCRIPTION
I really like the functionality of this extension, and am using it on Windows 10. I noticed a bug in the download completed notification, which is that the filename shown is the full path and the folder name shown is blank.

Looking at the code, I saw the reason for this is that this part of the path handling code only worked with forward slashes as a path separator. I am not experienced with Javascript, but have attempted to fix the issue by adding support for Windows paths.