### PR TITLE
Fix typo and bug in preferences screen

### DIFF
--- a/pref/config.json
+++ b/pref/config.json
@@ -38,6 +38,6 @@
         "defaultValue": 0,
         "min": 0,
         "name": "Don't Notify For Quick Downloads",
-        "description": "Don't send a notification for downloads quicker than this time (in seconds). If set to zero, no notifiations will be skipped. "
+        "description": "Don't send a notification for downloads quicker than this time (in seconds). If set to zero, no notifications will be skipped. "
     }
 }

--- a/pref/pref.js
+++ b/pref/pref.js
@@ -126,18 +126,13 @@ function restorePrefs()
             }
             if (window.addonConfig[key].type == 'bool')
             {
-                var isEnabled;
                 if (result[key] !== undefined)
                 {
-                    isEnabled = result[key]
+                    inputElem.checked = result[key];
                 }
                 else
                 {
-                    isEnabled = window.addonConfig[key].defaultValue;
-                }
-                if (isEnabled)
-                {
-                    inputElem.checked = true;
+                    inputElem.checked = window.addonConfig[key].defaultValue;
                 }
             }
             else if (window.addonConfig[key].type == 'int')


### PR DESCRIPTION
If a boolean setting like "Always automatically dismiss notifications" that is disabled by default was checked by the user, then clicking on Restore Defaults should uncheck it, but this wasn't happening.